### PR TITLE
device.js [70045] - PreviousSequenceNo is not defined

### DIFF
--- a/drivers/700045/device.js
+++ b/drivers/700045/device.js
@@ -25,6 +25,7 @@ class P700045 extends ZwaveDevice {
         rawReport.Properties1.hasOwnProperty('Key Attributes') &&
         rawReport.hasOwnProperty('Scene Number') &&
         rawReport.hasOwnProperty('Sequence Number')) {
+        if (typeof PreviousSequenceNo === "undefined") { var PreviousSequenceNo = 0; }
         if (rawReport['Sequence Number'] !== PreviousSequenceNo) {
           const remoteValue = {
             button: rawReport['Scene Number'].toString(),


### PR DESCRIPTION
Debugging 2.0.5 beta using the athom-cli #21:

**app.json**

>{
  "id": "com.popp",
  "sdk": 2,
  "name": {
    "en": "PoPP EU Z-Wave Products",
    "nl": "PoPP EU Z-Wave Producten"
  },
  "description": {
    "en": "PoPP EU Z-Wave products support for Homey @ Athom",
    "nl": "PoPP EU Z-Wave product ondersteuning voor Homey @ Athom"
  },
  "images": {
    "large": "/assets/images/large.jpg",
    "small": "/assets/images/small.jpg"
  },
  "version": "2.0.5",
  "compatibility": ">=1.5.3",
  "tags": {
    "en": [
      "scene controller",
      "remote",
      "remote control",
      "central scene",
      "scenes",
      "motion detection",
      "motion",
      "alarm",
      "door",
      "window",
...

`athom app run`

>┌────────────────────────────────────────────┐
│ Hey developer, we're hiring! View our open │
│ positions at https://go.athom.com/jobs     │
└────────────────────────────────────────────┘
✓ Validating app...
✓ Homey App validated successfully against level `debug`
✓ Packing Homey App...
✓ Installing Homey App on `Homey` (http://xxx.xxx.xxx.xxx:80)...
✓ Homey App `com.popp` successfully installed
✓ Running `com.popp`, press CTRL+C to quit
─────────────── Logging stdout & stderr ───────────────
(node:12156) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 __appInit listeners added. Use emitter.setMaxListeners() to increase limit
2018-07-17 01:38:46 [log] [PoPPZwave] PoPP Z-wave app is running...
2018-07-17 01:38:46 [log] [ManagerDrivers] [700045] [0] ZwaveDevice has been inited
/drivers/700045/device.js:28
        if (rawReport['Sequence Number'] !== PreviousSequenceNo) {
                                             ^
ReferenceError: PreviousSequenceNo is not defined
    at Object.registerReportListener [as CENTRAL_SCENE_NOTIFICATION] (/drivers/700045/device.js:28:46)
    at ZwaveCommandClass.commandClass.on (/node_modules/homey-meshdriver/lib/zwave/ZwaveDevice.js:845:56)
    at emitThree (events.js:136:13)
    at ZwaveCommandClass.emit (events.js:217:7)
    at ZwaveCommandClass._onReport (/opt/homey-client/system/manager/ManagerApps/bootstrap/sdk/v2/lib/ZwaveCommandClass.js:1:412)
    at emitOne (events.js:116:13)
    at ZwaveCommandClass.emit (events.js:211:7)
    at ZwaveNode._onReport (/opt/homey-client/system/manager/ManagerApps/bootstrap/sdk/v2/lib/ZwaveNode.js:1:1411)
    at emitOne (events.js:116:13)
    at ZwaveNode.emit (events.js:211:7)
--- INFO: com.popp has been killed ---`