### PR TITLE
[700045] keypad triggers added

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
     "large": "/assets/images/large.jpg",
     "small": "/assets/images/small.jpg"
   },
-  "version": "2.0.5",
+  "version": "2.0.6",
   "compatibility": ">=1.5.3",
   "tags": {
     "en": [
@@ -2796,7 +2796,7 @@
         ]
       },
       {
-        "id": "RC_scene",
+        "id": "user_validated",
         "title": {
           "en": "A user verified itself",
           "nl": "Een gebruiker is gevalideerd"
@@ -2964,6 +2964,62 @@
               }
             ]
           }
+        ]
+      },
+      {
+        "id": "code_invalid",
+        "title": {
+          "en": "A user entered an invalid code",
+          "nl": "Een gebruiker voerde een ongeldige code in"
+        },
+        "hint": {
+          "en": "This card triggers when a user enters an invalid code",
+          "nl": "Deze kaart wordt geactiveerd wanneer een gebruiker een verkeerde code geeft"
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=700045"
+          }
+        ]
+      },
+      {
+        "id": "ring_button",
+        "title": {
+          "en": "A user pressed the ring button",
+          "nl": "Een gebruiker drukte op de deurbel"
+        },
+        "hint": {
+          "en": "This card triggers when a user presses the doorbell button",
+          "nl": "Deze kaart wordt geactiveerd wanneer een gebruiker op de knop \"deurbel\" drukt"
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=700045"
+          },
+          {
+            "name": "button",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "21",
+                "label": {
+                  "en": "Key Pressed 1 time(s)",
+                  "nl": "Knop 1x ingedrukt"
+                }
+              },
+              {
+                "id": "22",
+                "label": {
+                  "en": "Key Pressed 2 times",
+                  "nl": "Knop 2x ingedrukt"
+                }
+              }
+            ]
+          }    
         ]
       },
       {

--- a/drivers/700045/device.js
+++ b/drivers/700045/device.js
@@ -11,13 +11,27 @@ class P700045 extends ZwaveDevice {
     this.registerCapability('alarm_battery', 'BATTERY');
 
     // define and register FlowCardTriggers
-    let triggerRC_scene = new Homey.FlowCardTriggerDevice('RC_scene');
-    triggerRC_scene
+    let triggerUser = new Homey.FlowCardTriggerDevice('user_validated');
+    triggerUser
       .register()
       .registerRunListener((args, state) => {
         //this.log(args, state);
-        return Promise.resolve(args.button === state.button && args.scene === state.scene);
-      });
+        return Promise.resolve(args.button === state.button || (args.button == 0 && state.button >= 1 && state.button <= 20) /* && args.scene === state.scene */ );
+      })
+
+    let triggerRing = new Homey.FlowCardTriggerDevice('ring_button');
+    triggerRing
+      .register()
+      .registerRunListener((args, state) => {
+        return Promise.resolve(args.button === state.button );
+      })
+
+    let triggerInvalid = new Homey.FlowCardTriggerDevice('code_invalid');
+    triggerInvalid
+      .register()
+      .registerRunListener((args, state) => {
+        return Promise.resolve(state.button === '23' );
+      })
 
     // register a report listener (SDK2 style not yet operational)
     this.registerReportListener('CENTRAL_SCENE', 'CENTRAL_SCENE_NOTIFICATION', (rawReport, parsedReport) => {
@@ -34,7 +48,19 @@ class P700045 extends ZwaveDevice {
           PreviousSequenceNo = rawReport['Sequence Number'];
           this.log('Triggering sequence:', PreviousSequenceNo, 'remoteValue', remoteValue);
           // Trigger the trigger card with 2 dropdown options
-          triggerRC_scene.trigger(this, triggerRC_scene.getArgumentValues, remoteValue);
+          if(remoteValue.button == 21 || remoteValue.button == 22) { // bell-button: 21=once; 22=twice
+            triggerRing
+              .trigger(this, triggerRing.getArgumentValues, remoteValue)
+              .catch( err => { this.log('ReportListener', err) } );
+          } else if(remoteValue.button == 23) { // unrecognized user code
+            triggerInvalid
+              .trigger(this, triggerInvalid.getArgumentValues, remoteValue)
+              .catch( err => { this.log('ReportListener', err) } );
+          } else { //assuming user code 1-20
+            triggerUser
+              .trigger(this, triggerUser.getArgumentValues, remoteValue)
+              .catch( err => { this.log('ReportListener', err) } );
+          }
         }
       }
     });


### PR DESCRIPTION
It's now possible to:
- distinguish individual codes (1-20)
- trigger on bell pressed (once or twice)
- trigger on non-existing user code

*Please note:*
Code has not been tested for backwards compatibility with existing flows and/or v1.5.x.
This code is working for me on Homey v2.0.0-rc.9