### PR TITLE
Add setting for relative air pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ b. change the setting to another value with above steps
 c. check if effective and retry to the desired value    
 
 ## Change Log:    
-   
+
+### v 2.0.10
+Z-Weather add setting for metres above sea level for showing relative air pressure
+
+### v 2.0.9
+Bugfixes
+ 
 ### v 2.0.8
 **fixed:** Keypad, Z-Rain, Z-Weather (Please reinclude that devices)
 Added support for Power Plug

--- a/app.json
+++ b/app.json
@@ -1650,6 +1650,23 @@
             "de": "Bei Überschreiten dieses Wertes wird ein Kommando in die Geräte der Assoziationsgruppe 3 gesendet. Gleichermaßen wird beim Unterschreiten dieses Wertes wird ein Kommando in die Geräte der Assoziationsgruppe 4 gesendet."
           },
           "type": "number"
+        },
+        {
+          "id": "metres_over_sea_level",
+          "value": 0,
+          "label": {
+            "en": "Metres above sea level",
+            "de": "Höhe über dem Meeresspiegel"
+          },
+          "attr": {
+            "min": 0,
+            "max": 8848
+          },
+          "hint": {
+            "en": "Indicate the altitude above sea level where the Z-Weather is installed. This is used to convert from absolute to relative air pressure.",
+            "de": "Gib die Höhe über dem Meeresspiegel an wo der Z-Weather installiert ist. Dies dient zur Umrechnung vom Absoluten auf Relativen Luftdruck"
+          },
+          "type": "number"
         }
       ]
     },

--- a/drivers/005206/device.js
+++ b/drivers/005206/device.js
@@ -40,7 +40,14 @@ class P005206 extends ZwaveDevice {
               report: 'SENSOR_MULTILEVEL_REPORT',
               reportParser: report => {
                 if (report && report.hasOwnProperty('Sensor Type') && report.hasOwnProperty('Sensor Value (Parsed)') && report['Sensor Type'] === 'Barometric pressure (version 2)' || report['Sensor Type'] === 'Barometric pressure (version 2) ') {
-                  return report['Sensor Value (Parsed)']*10;
+                  if (this.getSetting('metres_over_sea_level') >= 1)
+				  {
+				  return Math.round(report['Sensor Value (Parsed)']*10/Math.pow(1-(0.0065*this.getSetting('metres_over_sea_level'))/288.15, 5.255)) //simplified Barometric formula
+				  }
+				  else
+				  {
+				  return report['Sensor Value (Parsed)']*10;
+				  }
                 }
                 return null;
               }

--- a/drivers/005206/driver.settings.compose.json
+++ b/drivers/005206/driver.settings.compose.json
@@ -30,5 +30,23 @@
 		"de": "Bei Überschreiten dieses Wertes wird ein Kommando in die Geräte der Assoziationsgruppe 3 gesendet. Gleichermaßen wird beim Unterschreiten dieses Wertes wird ein Kommando in die Geräte der Assoziationsgruppe 4 gesendet."
       },
       "type": "number"
+    },
+	{
+      "id": "metres_over_sea_level",
+      "value": 0,
+      "label": {
+        "en": "Metres above sea level",
+		"de": "Höhe über dem Meeresspiegel"
+      },
+	 "attr": {
+      "min": 0,
+      "max": 8848 
+    },
+      "hint": {
+        "en": "Indicate the altitude above sea level where the Z-Weather is installed. This is used to convert from absolute to relative air pressure.",
+		"de": "Gib die Höhe über dem Meeresspiegel an wo der Z-Weather installiert ist. Dies dient zur Umrechnung vom Absoluten auf Relativen Luftdruck"
+      },
+      "type": "number"
     }
+	
   ]


### PR DESCRIPTION
This is a smaller update. It is just a setting where you can set you height over the sea where the Z-Weather is placed. 